### PR TITLE
Fix broken wallHitDirection code

### DIFF
--- a/RobotWarsOSX/Engine/MainScene.m
+++ b/RobotWarsOSX/Engine/MainScene.m
@@ -379,8 +379,8 @@ void calc_collisionAngle_WallHitDirection(CGPoint wallNormalVector, Robot *robot
     // Calculate Collision Angle
     *collisionAngle_p = angleSigned([robot headingDirection], wallNormalVector);
     *collisionAngle_p = roundf(radToDeg(*collisionAngle_p));
-    while (*collisionAngle_p < -180) { collisionAngle_p += 180; }
-    while (*collisionAngle_p > 180) { collisionAngle_p -= 180; }
+    while (*collisionAngle_p < -180) { *collisionAngle_p += 360; }
+    while (*collisionAngle_p > 180) { *collisionAngle_p -= 360; }
     *direction_p = radAngleToRobotWallHitDirection(*collisionAngle_p);
 }
 


### PR DESCRIPTION
this was doing incorrect pointer arithmetic, and with the wrong value (this is why we sometimes see robots ramming themselves into a wall forever)
